### PR TITLE
Fix clear color in qvideoframeconverter

### DIFF
--- a/src/multimedia/video/qvideoframeconverter.cpp
+++ b/src/multimedia/video/qvideoframeconverter.cpp
@@ -412,7 +412,7 @@ QImage qImageFromVideoFrame(const QVideoFrame &frame, QVideoFrame::RotationAngle
     QVideoTextureHelper::updateUniformData(&uniformData, frame.surfaceFormat(), frame, transform, 1.f);
     rub->updateDynamicBuffer(uniformBuffer.get(), 0, uniformData.size(), uniformData.constData());
 
-    cb->beginPass(renderTarget.get(), Qt::black, { 1.0f, 0 }, rub);
+    cb->beginPass(renderTarget.get(), Qt::transparent, { 1.0f, 0 }, rub);
     cb->setGraphicsPipeline(graphicsPipeline.get());
 
     cb->setViewport({ 0, 0, float(frameSize.width()), float(frameSize.height()) });


### PR DESCRIPTION
**Problem**
----
QVideoFrame::toImage() does not take into account transparency. Meaning alpha value of a pixel in a video is ignored and images appear to be always with 225 alpha value.

**Details**
----
I have a video with a transparent background (Some pixels are transparent). 
I pass it to a QMediaPlayer and connect my slot with a signal for any frame changes.

How it looks in code:
```
QMediaPlayer* player = new QMediaPlayer();
QVideoSink* videoSink = new QVideoSink();

QObject::connect(videoSink, &QVideoSink::videoFrameChanged,
                 this,      &MyWidget::videoFrameChanged);

player->setSource(QUrl::fromLocalFile("path/transparent_video.webm"));
player->setVideoSink(videoSink);

player->play();
```

When the frame changes, I have to convert QVideoFrame to QImage.
If using QVidoeFrame::toImage() the problem with transparency occurs:

```
void MyWidget::videoFrameChanged(const QVideoFrame &frame) const
{
    QImage image = frame.toImage();
    
    // For a test I made the very first pixel to be fully transparent, but:
    // *(image.bits() + 3) equals to 255
}
``` 

**Solution**
----
Solution is to make QRhiCommandBuffer::beginPass clear it's render target with transparent color and not with black.
(reference: https://alpqr.github.io/qtrhi/qrhicommandbuffer.html#beginPass)