### PR TITLE
Fixing "A lot of buffers are being dropped."

### DIFF
--- a/src/plugins/multimedia/gstreamer/common/qgstreamermediaplayer.cpp
+++ b/src/plugins/multimedia/gstreamer/common/qgstreamermediaplayer.cpp
@@ -32,8 +32,8 @@ QT_BEGIN_NAMESPACE
 QGstreamerMediaPlayer::TrackSelector::TrackSelector(TrackType type, QGstElement selector)
     : selector(selector), type(type)
 {
-    selector.set("sync-streams", true);
-    selector.set("sync-mode", 1 /*clock*/);
+    selector.set("sync-streams", false);
+    selector.set("sync-mode", 0 /*clock*/);
 
     if (type == SubtitleStream)
         selector.set("cache-buffers", true);


### PR DESCRIPTION
I was getting:
qt.multimedia.player: Warning: "A lot of buffers are being dropped." and the video was lagging.
According to here -> https://forums.developer.nvidia.com/t/error-a-lot-of-buffers-are-being-dropped-when-running-ds-sdk-python-sample-ipcamera-on-nano/110886 I changed the values and now I don't get the error but it still lagging a bit. Not so much.