### PR TITLE
Add null check in QtVideoDeviceManager.java to avoid crash

### DIFF
--- a/src/android/jar/src/org/qtproject/qt/android/multimedia/QtVideoDeviceManager.java
+++ b/src/android/jar/src/org/qtproject/qt/android/multimedia/QtVideoDeviceManager.java
@@ -110,6 +110,8 @@ public class QtVideoDeviceManager {
 
         StreamConfigurationMap map = characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
         Size[] sizes = map.getOutputSizes(imageFormat);
+        if (sizes == null)
+            return new String[0];
 
         String[] stream = new String[sizes.length];
 


### PR DESCRIPTION
This pull request fixes a SIGABRT crash spotted on Android when building our app against Qt 6.5.2.

The crash logs is as follow:
```
java.lang.NullPointerException: Attempt to get length of null array
	at org.qtproject.qt.android.multimedia.QtVideoDeviceManager.getStreamConfigurationsSizes(QtVideoDeviceManager.java:113)
	at org.qtproject.qt.android.QtNative.startQtApplication(Native Method)
	at org.qtproject.qt.android.QtNative$7.run(QtNative.java:465)
	at org.qtproject.qt.android.QtThread$1.run(QtThread.java:25)
	at java.lang.Thread.run(Thread.java:920)
```

It happens on Samsung Galaxy S10 devices when loading a QML scene containing a VideoOutput element. The stacktrace prior to the Java crash is:

![image](https://github.com/nirvn/qtmultimedia/assets/1728657/921a446e-ef60-4c56-9b0d-07873179c8d0)

I'm not intimidate with the C++ code calling the Java function (here: https://github.com/qt/qtmultimedia/blob/a17bdfa63c0f2c854b9d63361905ee467bd2ac41/src/plugins/multimedia/ffmpeg/qandroidvideodevices.cpp#L123), but I assume an additional null check can only be good :)