### PR TITLE
Fix sound effects being cut off on macOS

### DIFF
--- a/src/multimedia/audio/qsoundeffect.cpp
+++ b/src/multimedia/audio/qsoundeffect.cpp
@@ -25,12 +25,9 @@ struct AudioSinkDeleter
 {
     void operator ()(QAudioSink* sink) const
     {
-        // Wait for sink to finish before stopping it
-        if (sink->state() == QAudio::ActiveState) {
-            sink->drain();
-        }
+        // Stop sink before deleting it
         sink->stop();
-        
+
         // Delete sink immediately after it has stopped
         delete sink;
     }

--- a/src/multimedia/audio/qsoundeffect.cpp
+++ b/src/multimedia/audio/qsoundeffect.cpp
@@ -25,9 +25,14 @@ struct AudioSinkDeleter
 {
     void operator ()(QAudioSink* sink) const
     {
+        // Wait for sink to finish before stopping it
+        if (sink->state() == QAudio::ActiveState) {
+            sink->drain();
+        }
         sink->stop();
-        // Investigate:should we just delete?
-        sink->deleteLater();
+        
+        // Delete sink immediately after it has stopped
+        delete sink;
     }
 };
 


### PR DESCRIPTION
Wait for QAudioSink to finish playing before stopping it and ensure proper cleanup by using immediate deletion instead of calling deleteLater().

This should fix the issue of sound effects being cut off prematurely on macOS.